### PR TITLE
fix(client): respect user setting

### DIFF
--- a/client.go
+++ b/client.go
@@ -23,9 +23,13 @@ type Settings struct {
 }
 
 func NewClient(settings Settings) API {
-	c := &Client{token: settings.Token}
+	c := &Client{
+		token:      settings.Token,
+		endpoint:   settings.Endpoint,
+		httpclient: settings.HTTPClient,
+	}
 	if c.endpoint == "" {
-		c.endpoint = "https://api.notion.so"
+		c.endpoint = "https://api.notion.com"
 	}
 	if c.httpclient == nil {
 		c.httpclient = &http.Client{


### PR DESCRIPTION
API document: 
https://developers.notion.com/reference/intro

> The base URL to send all API requests is https://api.notion.com. HTTPS is required for all API requests.